### PR TITLE
feat(list): add numeric field type (#35)

### DIFF
--- a/list/src/CollectionView.tsx
+++ b/list/src/CollectionView.tsx
@@ -3,12 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { useStorage } from './storage';
 import { Item, generateId } from './Item';
 import { nameToSlug } from './slug';
-
-interface Field {
-  key: string;
-  name: string;
-  type: string;
-}
+import { type FieldDraft, type Field, fieldDefault, parseFieldValue } from './field';
 
 interface Schema {
   name: string;
@@ -25,7 +20,7 @@ export function CollectionView() {
   const [error, setError] = useState<string | null>(null);
   const [newItemName, setNewItemName] = useState<string | null>(null);
   const [addError, setAddError] = useState<string | null>(null);
-  const [newFieldForm, setNewFieldForm] = useState<{ name: string } | null>(null);
+  const [newFieldForm, setNewFieldForm] = useState<FieldDraft | null>(null);
   const [addFieldError, setAddFieldError] = useState<string | null>(null);
   const [editingCell, setEditingCell] = useState<{ itemId: string; fieldKey: string } | null>(null);
   const [editValue, setEditValue] = useState('');
@@ -72,7 +67,7 @@ export function CollectionView() {
 
     const defaults: Record<string, unknown> = {};
     for (const f of fields) {
-      defaults[f.key] = f.type === 'checkbox' ? false : f.type === 'number' ? null : '';
+      defaults[f.key] = fieldDefault(f);
     }
     const newItem: Item = { id: generateId(), name, ...defaults };
     const updatedItems = [...items, newItem];
@@ -88,13 +83,14 @@ export function CollectionView() {
   }
 
   function openNewFieldForm() {
-    setNewFieldForm({ name: '' });
+    setNewFieldForm({ name: '', type: 'text' });
     setAddFieldError(null);
     requestAnimationFrame(() => newFieldInputRef.current?.focus());
   }
 
   async function submitNewField() {
-    const name = newFieldForm?.name.trim();
+    if (!newFieldForm) return;
+    const name = newFieldForm.name.trim();
     if (!name) return;
 
     const key = nameToSlug(name) || name.toLowerCase().replace(/\s+/g, '-');
@@ -103,9 +99,16 @@ export function CollectionView() {
       return;
     }
 
-    const newField: Field = { key, name, type: 'text' };
+    let newField: Field;
+    if (newFieldForm.type === 'number') {
+      newField = { key, name, type: 'number', mode: newFieldForm.mode };
+    } else if (newFieldForm.type === 'checkbox') {
+      newField = { key, name, type: 'checkbox' };
+    } else {
+      newField = { key, name, type: 'text' };
+    }
     const updatedFields = [...fields, newField];
-    const defaultValue = '';
+    const defaultValue = fieldDefault(newField);
     const updatedItems = items.map(item => ({ ...item, [newField.key]: defaultValue }));
 
     try {
@@ -130,8 +133,10 @@ export function CollectionView() {
   async function commitEdit(itemId: string, fieldKey: string) {
     if (cancelEdit.current) { cancelEdit.current = false; return; }
     setEditingCell(null);
+    const field = fields.find(f => f.key === fieldKey);
+    const value = field ? parseFieldValue(editValue, field) : editValue;
     const updatedItems = items.map(item =>
-      item.id === itemId ? { ...item, [fieldKey]: editValue } : item
+      item.id === itemId ? { ...item, [fieldKey]: value } : item
     );
     setItems(updatedItems);
     try {
@@ -160,7 +165,8 @@ export function CollectionView() {
               <span className="item-field-label">{f.name}</span>
               {isEditing ? (
                 <input
-                  type="text"
+                  type={f.type}
+                  step={f.type === 'number' && f.mode === 'decimal' ? 'any' : undefined}
                   className="item-field-edit"
                   autoFocus
                   value={editValue}
@@ -188,12 +194,40 @@ export function CollectionView() {
               placeholder="Field name"
               autoComplete="off"
               value={newFieldForm.name}
-              onChange={e => { setNewFieldForm({ name: e.target.value }); setAddFieldError(null); }}
+              onChange={e => { setNewFieldForm({ ...newFieldForm, name: e.target.value }); setAddFieldError(null); }}
               onKeyDown={e => {
                 if (e.key === 'Enter') submitNewField();
                 if (e.key === 'Escape') setNewFieldForm(null);
               }}
             />
+            <select
+              className="item-new-field-type"
+              value={newFieldForm.type}
+              onChange={e => {
+                const t = e.target.value as 'text' | 'number' | 'checkbox';
+                setNewFieldForm(t === 'number'
+                  ? { name: newFieldForm.name, type: 'number', mode: 'integer' }
+                  : { name: newFieldForm.name, type: t });
+              }}
+            >
+              <option value="text">text</option>
+              <option value="number">number</option>
+              <option value="checkbox">checkbox</option>
+            </select>
+            {newFieldForm.type === 'number' && (
+              <select
+                className="item-new-field-mode"
+                value={newFieldForm.mode}
+                onChange={e => setNewFieldForm({
+                  name: newFieldForm.name,
+                  type: 'number',
+                  mode: e.target.value as 'integer' | 'decimal',
+                })}
+              >
+                <option value="integer">integer</option>
+                <option value="decimal">decimal</option>
+              </select>
+            )}
             {index === 0 && addFieldError && <span className="form-error">{addFieldError}</span>}
             <button className="btn-icon btn-icon-small" onClick={() => setNewFieldForm(null)} title="Cancel">
               <svg className="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/list/src/CollectionView.tsx
+++ b/list/src/CollectionView.tsx
@@ -204,7 +204,7 @@ export function CollectionView() {
               className="item-new-field-type"
               value={newFieldForm.type}
               onChange={e => {
-                const t = e.target.value as 'text' | 'number' | 'checkbox';
+                const t = e.target.value as 'text' | 'number';
                 setNewFieldForm(t === 'number'
                   ? { name: newFieldForm.name, type: 'number', mode: 'integer' }
                   : { name: newFieldForm.name, type: t });
@@ -212,7 +212,6 @@ export function CollectionView() {
             >
               <option value="text">text</option>
               <option value="number">number</option>
-              <option value="checkbox">checkbox</option>
             </select>
             {newFieldForm.type === 'number' && (
               <select

--- a/list/src/field.integration.test.ts
+++ b/list/src/field.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration tests: how fieldDefault and parseFieldValue interact with
+ * Field schemas and Item records — mirroring the data flows in CollectionView:
+ *
+ *  submitNewField  → fieldDefault applied to existing items
+ *  submitNewItem   → fieldDefault applied to new item
+ *  commitEdit      → parseFieldValue applied to updated item
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fieldDefault, parseFieldValue } from './field';
+import type { Field } from './field';
+import type { Item } from './Item';
+
+// ---------------------------------------------------------------------------
+// Simulated submitNewField: backfill existing items with field default
+// ---------------------------------------------------------------------------
+
+describe('adding a number field backfills existing items with 0', () => {
+  const existingItems: Item[] = [
+    { id: 'a', name: 'Alpha' },
+    { id: 'b', name: 'Beta', notes: 'some text' },
+  ];
+
+  const newField: Field = { key: 'qty', name: 'Qty', type: 'number', mode: 'integer' };
+  const defaultValue = fieldDefault(newField);
+  const updatedItems = existingItems.map(item => ({ ...item, [newField.key]: defaultValue }));
+
+  it('adds the field key to every item', () => {
+    expect(updatedItems.every(i => 'qty' in i)).toBe(true);
+  });
+
+  it('sets the default to 0 (number, not string)', () => {
+    expect(updatedItems[0].qty).toBe(0);
+    expect(typeof updatedItems[0].qty).toBe('number');
+  });
+
+  it('preserves existing fields on items', () => {
+    expect(updatedItems[1].notes).toBe('some text');
+  });
+
+  it('does not mutate the original items', () => {
+    expect('qty' in existingItems[0]).toBe(false);
+  });
+});
+
+describe('adding a text field backfills existing items with empty string', () => {
+  const existingItems: Item[] = [{ id: 'a', name: 'Alpha', qty: 5 }];
+  const newField: Field = { key: 'notes', name: 'Notes', type: 'text' };
+  const updatedItems = existingItems.map(item => ({ ...item, [newField.key]: fieldDefault(newField) }));
+
+  it('sets the default to empty string', () => {
+    expect(updatedItems[0].notes).toBe('');
+  });
+});
+
+describe('adding a checkbox field backfills existing items with false', () => {
+  const existingItems: Item[] = [{ id: 'a', name: 'Alpha' }];
+  const newField: Field = { key: 'done', name: 'Done', type: 'checkbox' };
+  const updatedItems = existingItems.map(item => ({ ...item, [newField.key]: fieldDefault(newField) }));
+
+  it('sets the default to false', () => {
+    expect(updatedItems[0].done).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Simulated submitNewItem: apply field defaults when creating a new item
+// ---------------------------------------------------------------------------
+
+describe('new item gets correct defaults across a mixed-type schema', () => {
+  const fields: Field[] = [
+    { key: 'qty',   name: 'Qty',   type: 'number',   mode: 'integer' },
+    { key: 'price', name: 'Price', type: 'number',   mode: 'decimal' },
+    { key: 'done',  name: 'Done',  type: 'checkbox' },
+    { key: 'notes', name: 'Notes', type: 'text' },
+  ];
+
+  const defaults: Record<string, unknown> = {};
+  for (const f of fields) defaults[f.key] = fieldDefault(f);
+  const newItem: Item = { id: 'x', name: 'New Item', ...defaults };
+
+  it('integer field defaults to 0', () => {
+    expect(newItem.qty).toBe(0);
+    expect(typeof newItem.qty).toBe('number');
+  });
+
+  it('decimal field defaults to 0', () => {
+    expect(newItem.price).toBe(0);
+    expect(typeof newItem.price).toBe('number');
+  });
+
+  it('checkbox field defaults to false', () => {
+    expect(newItem.done).toBe(false);
+  });
+
+  it('text field defaults to empty string', () => {
+    expect(newItem.notes).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Simulated commitEdit: parse raw edit value and apply to item
+// ---------------------------------------------------------------------------
+
+describe('editing an integer field updates item with a number', () => {
+  const item: Item = { id: 'a', name: 'Alpha', qty: 0 };
+  const field: Field = { key: 'qty', name: 'Qty', type: 'number', mode: 'integer' };
+
+  function applyEdit(items: Item[], itemId: string, fieldKey: string, raw: string): Item[] {
+    const f = [field].find(f => f.key === fieldKey)!;
+    return items.map(i => i.id === itemId ? { ...i, [fieldKey]: parseFieldValue(raw, f) } : i);
+  }
+
+  it('stores the parsed integer, not the raw string', () => {
+    const updated = applyEdit([item], 'a', 'qty', '42');
+    expect(updated[0].qty).toBe(42);
+    expect(typeof updated[0].qty).toBe('number');
+  });
+
+  it('stores 0 when input is cleared', () => {
+    const updated = applyEdit([item], 'a', 'qty', '');
+    expect(updated[0].qty).toBe(0);
+  });
+
+  it('does not affect other items', () => {
+    const items: Item[] = [item, { id: 'b', name: 'Beta', qty: 7 }];
+    const updated = applyEdit(items, 'a', 'qty', '99');
+    expect(updated[1].qty).toBe(7);
+  });
+});
+
+describe('editing a decimal field updates item with a float', () => {
+  const item: Item = { id: 'a', name: 'Alpha', price: 0 };
+  const field: Field = { key: 'price', name: 'Price', type: 'number', mode: 'decimal' };
+
+  it('stores the parsed float', () => {
+    const updated = [item].map(i => ({ ...i, price: parseFieldValue('9.99', field) }));
+    expect(updated[0].price).toBeCloseTo(9.99);
+    expect(typeof updated[0].price).toBe('number');
+  });
+});
+
+describe('editing a text field keeps value as string', () => {
+  const item: Item = { id: 'a', name: 'Alpha', notes: '' };
+  const field: Field = { key: 'notes', name: 'Notes', type: 'text' };
+
+  it('stores the string as-is', () => {
+    const updated = [item].map(i => ({ ...i, notes: parseFieldValue('hello world', field) }));
+    expect(updated[0].notes).toBe('hello world');
+  });
+});

--- a/list/src/field.test.ts
+++ b/list/src/field.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { fieldDefault, parseFieldValue } from './field';
+import type { Field } from './field';
+
+// ---------------------------------------------------------------------------
+// fieldDefault
+// ---------------------------------------------------------------------------
+
+describe('fieldDefault', () => {
+  it('returns empty string for text fields', () => {
+    expect(fieldDefault({ name: 'Notes', type: 'text' })).toBe('');
+  });
+
+  it('returns false for checkbox fields', () => {
+    expect(fieldDefault({ name: 'Done', type: 'checkbox' })).toBe(false);
+  });
+
+  it('returns 0 for integer number fields', () => {
+    expect(fieldDefault({ name: 'Qty', type: 'number', mode: 'integer' })).toBe(0);
+  });
+
+  it('returns 0 for decimal number fields', () => {
+    expect(fieldDefault({ name: 'Price', type: 'number', mode: 'decimal' })).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFieldValue — text fields (passthrough)
+// ---------------------------------------------------------------------------
+
+describe('parseFieldValue — text', () => {
+  const field: Field = { key: 'notes', name: 'Notes', type: 'text' };
+
+  it('returns the raw string unchanged', () => {
+    expect(parseFieldValue('hello', field)).toBe('hello');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(parseFieldValue('', field)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFieldValue — checkbox fields (passthrough)
+// ---------------------------------------------------------------------------
+
+describe('parseFieldValue — checkbox', () => {
+  const field: Field = { key: 'done', name: 'Done', type: 'checkbox' };
+
+  it('returns the raw string unchanged', () => {
+    expect(parseFieldValue('true', field)).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFieldValue — integer number fields
+// ---------------------------------------------------------------------------
+
+describe('parseFieldValue — number (integer)', () => {
+  const field: Field = { key: 'qty', name: 'Qty', type: 'number', mode: 'integer' };
+
+  it('parses a whole number string to a number', () => {
+    expect(parseFieldValue('42', field)).toBe(42);
+  });
+
+  it('truncates decimal input to integer', () => {
+    expect(parseFieldValue('3.7', field)).toBe(3);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseFieldValue('', field)).toBe(0);
+  });
+
+  it('returns 0 for non-numeric string', () => {
+    expect(parseFieldValue('abc', field)).toBe(0);
+  });
+
+  it('parses negative integers', () => {
+    expect(parseFieldValue('-5', field)).toBe(-5);
+  });
+
+  it('returns a number type (not string)', () => {
+    expect(typeof parseFieldValue('10', field)).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFieldValue — decimal number fields
+// ---------------------------------------------------------------------------
+
+describe('parseFieldValue — number (decimal)', () => {
+  const field: Field = { key: 'price', name: 'Price', type: 'number', mode: 'decimal' };
+
+  it('parses a decimal string to a number', () => {
+    expect(parseFieldValue('9.99', field)).toBeCloseTo(9.99);
+  });
+
+  it('parses a whole number string to a number', () => {
+    expect(parseFieldValue('42', field)).toBe(42);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseFieldValue('', field)).toBe(0);
+  });
+
+  it('returns 0 for non-numeric string', () => {
+    expect(parseFieldValue('abc', field)).toBe(0);
+  });
+
+  it('parses negative decimals', () => {
+    expect(parseFieldValue('-1.5', field)).toBeCloseTo(-1.5);
+  });
+
+  it('returns a number type (not string)', () => {
+    expect(typeof parseFieldValue('3.14', field)).toBe('number');
+  });
+});

--- a/list/src/field.ts
+++ b/list/src/field.ts
@@ -1,0 +1,27 @@
+export type FieldDraft =
+  | { name: string; type: 'text' }
+  | { name: string; type: 'number'; mode: 'integer' | 'decimal' }
+  | { name: string; type: 'checkbox' };
+
+export type Field = FieldDraft & { key: string };
+
+/** Default value to store for a new field on existing items. */
+export function fieldDefault(field: FieldDraft): unknown {
+  if (field.type === 'checkbox') return false;
+  if (field.type === 'number') return 0;
+  return '';
+}
+
+/** Parse a raw string edit value into the correct stored type for the field. */
+export function parseFieldValue(raw: string, field: Field): unknown {
+  if (field.type === 'number') {
+    if (field.mode === 'integer') {
+      const n = parseInt(raw, 10);
+      return isNaN(n) ? 0 : n;
+    } else {
+      const n = parseFloat(raw);
+      return isNaN(n) ? 0 : n;
+    }
+  }
+  return raw;
+}

--- a/list/src/style.css
+++ b/list/src/style.css
@@ -380,6 +380,17 @@ a:focus-visible {
     color: #bbb;
 }
 
+.item-new-field-type,
+.item-new-field-mode {
+    font-size: 13px;
+    color: #2c3e50;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #ccc;
+    padding: 2px 0;
+    cursor: pointer;
+    outline: none;
+}
 
 /* ============================================================================
    Responsive

--- a/list/tests/numeric-field.spec.js
+++ b/list/tests/numeric-field.spec.js
@@ -1,0 +1,201 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_PREFIX = 'numeric-field-test-';
+
+function nameToSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 100);
+}
+
+async function createCollectionViaApi(request, name, fields = [], items = []) {
+  const slug = nameToSlug(name);
+  await request.put(`/api/list/data/${slug}/schema.json`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify({ name, fields })
+  });
+  await request.put(`/api/list/data/${slug}/items.json`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(items)
+  });
+  return slug;
+}
+
+async function createCollectionWithItem(request, name, fields = []) {
+  return createCollectionViaApi(request, name, fields, [{ id: 'seed1', name: 'Seed Item' }]);
+}
+
+async function deleteCollectionViaApi(request, slug) {
+  await request.delete(`/api/list/data/${slug}?recursive=true`).catch(() => {});
+}
+
+async function gotoCollectionView(page, slug) {
+  await page.goto(`/list/#/collection/${slug}`);
+  await page.waitForSelector('.item-list:not(:has(.loading))');
+}
+
+async function clickAddField(page) {
+  await page.locator('.item-row button[title="Add field"]').first().click();
+}
+
+test.describe('List - Numeric Field', () => {
+  test.afterEach(async ({ request }) => {
+    const res = await request.get('/api/list/data/').catch(() => null);
+    if (!res?.ok()) return;
+    const entries = await res.json().catch(() => []);
+    for (const entry of entries) {
+      if (entry.type === 'dir' && entry.name.startsWith(TEST_PREFIX)) {
+        await deleteCollectionViaApi(request, entry.name);
+      }
+    }
+  });
+
+  test('should show a type selector in the add-field form', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'type-sel-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await expect(page.locator('.item-new-field-type')).toBeVisible();
+    await expect(page.locator('.item-new-field-type')).toHaveValue('text');
+  });
+
+  test('should show numeric mode selector only when type is number', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'mode-sel-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await expect(page.locator('.item-new-field-mode')).not.toBeVisible();
+
+    await page.locator('.item-new-field-type').selectOption('number');
+    await expect(page.locator('.item-new-field-mode')).toBeVisible();
+    await expect(page.locator('.item-new-field-mode')).toHaveValue('integer');
+  });
+
+  test('should persist integer number field in schema.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'schema-int-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Quantity');
+    await page.locator('.item-new-field-type').selectOption('number');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
+
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(schema.fields).toHaveLength(1);
+    expect(schema.fields[0].name).toBe('Quantity');
+    expect(schema.fields[0].type).toBe('number');
+    expect(schema.fields[0].mode).toBe('integer');
+  });
+
+  test('should persist decimal number field in schema.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'schema-dec-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Price');
+    await page.locator('.item-new-field-type').selectOption('number');
+    await page.locator('.item-new-field-mode').selectOption('decimal');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(schema.fields[0].type).toBe('number');
+    expect(schema.fields[0].mode).toBe('decimal');
+  });
+
+  test('should set 0 as default value for number fields on existing items', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'default-' + Date.now();
+    const slug = await createCollectionViaApi(request, name, [], [{ id: 'i1', name: 'Existing Item' }]);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Score');
+    await page.locator('.item-new-field-type').selectOption('number');
+    await page.locator('.item-new-field-input').press('Enter');
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(items[0][schema.fields[0].key]).toBe(0);
+  });
+
+  test('should render type=number input when editing a number field', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'input-type-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'qty', name: 'Quantity', type: 'number', mode: 'integer' }],
+      [{ id: 'i1', name: 'Item A', qty: 5 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '5' }).click();
+
+    await expect(page.locator('.item-field-edit')).toHaveAttribute('type', 'number');
+  });
+
+  test('should save integer field value as a number in items.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'save-int-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'qty', name: 'Quantity', type: 'number', mode: 'integer' }],
+      [{ id: 'i1', name: 'Item A', qty: 1 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '1' }).click();
+    await page.locator('.item-field-edit').fill('42');
+    await page.locator('.item-field-edit').press('Enter');
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    expect(items[0].qty).toBe(42);
+    expect(typeof items[0].qty).toBe('number');
+  });
+
+  test('should save decimal field value as a number in items.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'save-dec-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'number', mode: 'decimal' }],
+      [{ id: 'i1', name: 'Item A', price: 1.0 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '1' }).click();
+    await page.locator('.item-field-edit').fill('9.99');
+    await page.locator('.item-field-edit').press('Enter');
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    expect(items[0].price).toBeCloseTo(9.99);
+    expect(typeof items[0].price).toBe('number');
+  });
+
+  test('should save 0 when a number field is cleared', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'clear-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'qty', name: 'Quantity', type: 'number', mode: 'integer' }],
+      [{ id: 'i1', name: 'Item A', qty: 10 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '10' }).click();
+    await page.locator('.item-field-edit').fill('');
+    await page.locator('.item-field-edit').press('Enter');
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    expect(items[0].qty).toBe(0);
+  });
+
+  test('should still add a text field when type stays as text', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'text-regression-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Notes');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(schema.fields[0].type).toBe('text');
+    expect(schema.fields[0].mode).toBeUndefined();
+  });
+});

--- a/list/tests/numeric-field.spec.js
+++ b/list/tests/numeric-field.spec.js
@@ -100,6 +100,7 @@ test.describe('List - Numeric Field', () => {
     await page.locator('.item-new-field-type').selectOption('number');
     await page.locator('.item-new-field-mode').selectOption('decimal');
     await page.locator('.item-new-field-input').press('Enter');
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
 
     const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
     expect(schema.fields[0].type).toBe('number');
@@ -193,6 +194,7 @@ test.describe('List - Numeric Field', () => {
 
     await page.locator('.item-new-field-input').fill('Notes');
     await page.locator('.item-new-field-input').press('Enter');
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
 
     const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
     expect(schema.fields[0].type).toBe('text');


### PR DESCRIPTION
## Summary

- Add `number` field type to collections, configurable as `integer` or `decimal`
- Extract shared `Field`/`FieldDraft` types and `fieldDefault`/`parseFieldValue` helpers into `src/field.ts`
- Type selector and optional mode selector added to the inline add-field form
- Edit input uses `type="number"` for number fields; values saved as JSON numbers (not strings)

## Test plan

- [ ] Unit tests (`src/field.test.ts`) — `fieldDefault` and `parseFieldValue` in isolation
- [ ] Integration tests (`src/field.integration.test.ts`) — default backfill, new item creation, and edit commit flows
- [ ] E2E tests (`tests/numeric-field.spec.js`) — type selector UI, schema persistence, input type attribute, value saving, regression for text fields
- [ ] All 60 tests pass: `npm test`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)