### PR TITLE
feat(list): mobile list view with item detail route

### DIFF
--- a/list/src/App.tsx
+++ b/list/src/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import { CollectionList } from './CollectionList';
 import { CollectionView } from './CollectionView';
+import { ItemDetail } from './ItemDetail';
 
 export default function App() {
   return (
@@ -8,6 +9,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<CollectionList />} />
         <Route path="/collection/:slug" element={<CollectionView />} />
+        <Route path="/collection/:slug/item/:id" element={<ItemDetail />} />
       </Routes>
     </HashRouter>
   );

--- a/list/src/CollectionView.tsx
+++ b/list/src/CollectionView.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useStorage } from './storage';
 import { Item, generateId } from './Item';
-import { nameToSlug } from './slug';
 
 interface Field {
   key: string;
@@ -25,21 +24,17 @@ export function CollectionView() {
   const [error, setError] = useState<string | null>(null);
   const [newItemName, setNewItemName] = useState<string | null>(null);
   const [addError, setAddError] = useState<string | null>(null);
-  const [newFieldForm, setNewFieldForm] = useState<{ name: string } | null>(null);
-  const [addFieldError, setAddFieldError] = useState<string | null>(null);
-  const [editingCell, setEditingCell] = useState<{ itemId: string; fieldKey: string } | null>(null);
-  const [editValue, setEditValue] = useState('');
-  const cancelEdit = useRef(false);
   const newItemInputRef = useRef<HTMLInputElement>(null);
-  const newFieldInputRef = useRef<HTMLInputElement>(null);
 
   const loadData = useCallback(async () => {
     if (!slug) return;
     try {
       setLoading(true);
       setError(null);
-      const schema = await storage.fetchJSON(`/${slug}/schema.json`) as Schema | null;
-      const loaded = await storage.fetchJSON(`/${slug}/items.json`) as Item[] | null;
+      const [schema, loaded] = await Promise.all([
+        storage.fetchJSON(`/${slug}/schema.json`) as Promise<Schema | null>,
+        storage.fetchJSON(`/${slug}/items.json`) as Promise<Item[] | null>,
+      ]);
       if (schema) setCollectionName(schema.name);
       setFields(Array.isArray(schema?.fields) ? schema.fields as Field[] : []);
       setItems(Array.isArray(loaded) ? loaded : []);
@@ -87,129 +82,26 @@ export function CollectionView() {
     }
   }
 
-  function openNewFieldForm() {
-    setNewFieldForm({ name: '' });
-    setAddFieldError(null);
-    requestAnimationFrame(() => newFieldInputRef.current?.focus());
-  }
-
-  async function submitNewField() {
-    const name = newFieldForm?.name.trim();
-    if (!name) return;
-
-    const key = nameToSlug(name) || name.toLowerCase().replace(/\s+/g, '-');
-    if (fields.some(f => f.key === key)) {
-      setAddFieldError('A field with this name already exists');
-      return;
-    }
-
-    const newField: Field = { key, name, type: 'text' };
-    const updatedFields = [...fields, newField];
-    const defaultValue = '';
-    const updatedItems = items.map(item => ({ ...item, [newField.key]: defaultValue }));
-
-    try {
-      await storage.saveJSON(`/${slug}/schema.json`, { name: collectionName, fields: updatedFields });
-      await storage.saveJSON(`/${slug}/items.json`, updatedItems);
-      setFields(updatedFields);
-      setItems(updatedItems);
-      setNewFieldForm(null);
-      setAddFieldError(null);
-    } catch (err) {
-      console.error('Failed to add field:', err);
-      setAddFieldError('Failed to add field');
-    }
-  }
-
-  function startEdit(itemId: string, fieldKey: string, currentValue: unknown) {
-    setEditingCell({ itemId, fieldKey });
-    setEditValue(String(currentValue ?? ''));
-    cancelEdit.current = false;
-  }
-
-  async function commitEdit(itemId: string, fieldKey: string) {
-    if (cancelEdit.current) { cancelEdit.current = false; return; }
-    setEditingCell(null);
-    const updatedItems = items.map(item =>
-      item.id === itemId ? { ...item, [fieldKey]: editValue } : item
-    );
-    setItems(updatedItems);
-    try {
-      await storage.saveJSON(`/${slug}/items.json`, updatedItems);
-    } catch (err) {
-      console.error('Failed to save field value:', err);
-      setItems(items);
-    }
-  }
 
   function renderItems() {
     if (loading) return <div className="loading">Loading...</div>;
     if (error) return <div className="error">{error}</div>;
     if (items.length === 0) return <div className="empty-state">No items yet. Add one to get started.</div>;
-    return items.map((item, index) => (
-      <div key={item.id} className="item-row">
-        <span className="item-name">{typeof item.name === 'string' ? item.name : 'Untitled'}</span>
-        {fields.map(f => {
-          const isEditing = editingCell?.itemId === item.id && editingCell?.fieldKey === f.key;
-          return (
-            <div
-              key={f.key}
-              className={`item-field-row${isEditing ? '' : ' item-field-row-clickable'}`}
-              onClick={isEditing ? undefined : () => startEdit(item.id, f.key, item[f.key])}
-            >
-              <span className="item-field-label">{f.name}</span>
-              {isEditing ? (
-                <input
-                  type="text"
-                  className="item-field-edit"
-                  autoFocus
-                  value={editValue}
-                  onChange={e => setEditValue(e.target.value)}
-                  onBlur={() => commitEdit(item.id, f.key)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') { e.currentTarget.blur(); }
-                    if (e.key === 'Escape') { cancelEdit.current = true; setEditingCell(null); }
-                  }}
-                />
-              ) : (
-                <span className="item-field-value">
-                  {String(item[f.key] ?? '')}
-                </span>
-              )}
-            </div>
-          );
-        })}
-        {newFieldForm !== null ? (
-          <div className="item-new-field-form">
-            <input
-              ref={index === 0 ? newFieldInputRef : undefined}
-              type="text"
-              className="item-new-field-input"
-              placeholder="Field name"
-              autoComplete="off"
-              value={newFieldForm.name}
-              onChange={e => { setNewFieldForm({ name: e.target.value }); setAddFieldError(null); }}
-              onKeyDown={e => {
-                if (e.key === 'Enter') submitNewField();
-                if (e.key === 'Escape') setNewFieldForm(null);
-              }}
-            />
-            {index === 0 && addFieldError && <span className="form-error">{addFieldError}</span>}
-            <button className="btn-icon btn-icon-small" onClick={() => setNewFieldForm(null)} title="Cancel">
-              <svg className="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M18 6L6 18M6 6l12 12"/>
-              </svg>
-            </button>
-          </div>
-        ) : (
-          <button className="btn-add-field" onClick={openNewFieldForm} title="Add field">
-            <svg className="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M12 5v14M5 12h14"/>
-            </svg>
-            add field
-          </button>
-        )}
-      </div>
+    return items.map((item) => (
+      <Link
+        key={item.id}
+        to={`/collection/${slug}/item/${item.id}`}
+        className="item-row-link"
+      >
+        <div className="item-row">
+          <span className="item-name">{typeof item.name === 'string' ? item.name : 'Untitled'}</span>
+          {fields.slice(0, 2).map(f => (
+            <span key={f.key} className="item-preview-value">
+              {String(item[f.key] ?? '')}
+            </span>
+          ))}
+        </div>
+      </Link>
     ));
   }
 

--- a/list/src/ItemDetail.tsx
+++ b/list/src/ItemDetail.tsx
@@ -1,0 +1,208 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useStorage } from './storage';
+import { Item } from './Item';
+import { nameToSlug } from './slug';
+
+interface Field {
+  key: string;
+  name: string;
+  type: string;
+}
+
+interface Schema {
+  name: string;
+  fields: Field[];
+}
+
+export function ItemDetail() {
+  const { slug, id } = useParams<{ slug: string; id: string }>();
+  const storage = useStorage();
+  const [collectionName, setCollectionName] = useState<string>(slug ?? '');
+  const [item, setItem] = useState<Item | null>(null);
+  const [fields, setFields] = useState<Field[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newFieldForm, setNewFieldForm] = useState<{ name: string } | null>(null);
+  const [addFieldError, setAddFieldError] = useState<string | null>(null);
+  const [editingCell, setEditingCell] = useState<{ fieldKey: string } | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const cancelEdit = useRef(false);
+  const newFieldInputRef = useRef<HTMLInputElement>(null);
+
+  const loadData = useCallback(async () => {
+    if (!slug || !id) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const [schema, loaded] = await Promise.all([
+        storage.fetchJSON(`/${slug}/schema.json`) as Promise<Schema | null>,
+        storage.fetchJSON(`/${slug}/items.json`) as Promise<Item[] | null>,
+      ]);
+      if (schema) setCollectionName(schema.name);
+      setFields(Array.isArray(schema?.fields) ? schema.fields as Field[] : []);
+      const foundItem = Array.isArray(loaded) ? loaded.find(i => i.id === id) : null;
+      if (!foundItem) {
+        setError('Item not found');
+        setItem(null);
+      } else {
+        setItem(foundItem);
+      }
+    } catch (err) {
+      console.error('Failed to load item:', err);
+      setError('Failed to load item');
+    } finally {
+      setLoading(false);
+    }
+  }, [slug, id, storage]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  function openNewFieldForm() {
+    setNewFieldForm({ name: '' });
+    setAddFieldError(null);
+    requestAnimationFrame(() => newFieldInputRef.current?.focus());
+  }
+
+  async function submitNewField() {
+    const name = newFieldForm?.name.trim();
+    if (!name) return;
+
+    const key = nameToSlug(name);
+    if (fields.some(f => f.key === key)) {
+      setAddFieldError('A field with this name already exists');
+      return;
+    }
+
+    const newField: Field = { key, name, type: 'text' };
+    const updatedFields = [...fields, newField];
+    const defaultValue = '';
+
+    try {
+      await storage.saveJSON(`/${slug}/schema.json`, { name: collectionName, fields: updatedFields });
+      const allItems = await storage.fetchJSON(`/${slug}/items.json`) as Item[] | null;
+      const updatedItems = Array.isArray(allItems)
+        ? allItems.map(i => ({ ...i, [newField.key]: defaultValue }))
+        : [];
+      await storage.saveJSON(`/${slug}/items.json`, updatedItems);
+
+      setFields(updatedFields);
+      if (item) {
+        setItem({ ...item, [newField.key]: defaultValue });
+      }
+      setNewFieldForm(null);
+      setAddFieldError(null);
+    } catch (err) {
+      console.error('Failed to add field:', err);
+      setAddFieldError('Failed to add field');
+    }
+  }
+
+  function startEdit(fieldKey: string, currentValue: unknown) {
+    setEditingCell({ fieldKey });
+    setEditValue(String(currentValue ?? ''));
+    cancelEdit.current = false;
+  }
+
+  async function commitEdit(fieldKey: string) {
+    if (cancelEdit.current) { cancelEdit.current = false; return; }
+    setEditingCell(null);
+    if (!item) return;
+
+    const updatedItem = { ...item, [fieldKey]: editValue };
+    setItem(updatedItem);
+
+    try {
+      const allItems = await storage.fetchJSON(`/${slug}/items.json`) as Item[] | null;
+      const updatedItems = Array.isArray(allItems)
+        ? allItems.map(i => i.id === item.id ? updatedItem : i)
+        : [updatedItem];
+      await storage.saveJSON(`/${slug}/items.json`, updatedItems);
+    } catch (err) {
+      console.error('Failed to save field value:', err);
+      setItem(item);
+    }
+  }
+
+  if (loading) return <div className="loading">Loading...</div>;
+  if (error) return <div className="error">{error}</div>;
+  if (!item) return <div className="empty-state">Item not found</div>;
+
+  return (
+    <div className="container">
+      <div className="header">
+        <Link to={`/collection/${slug}`} className="btn-icon btn-icon-left" title="Back">
+          <svg className="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M19 12H5M12 5l-7 7 7 7"/>
+          </svg>
+        </Link>
+        <h1>{typeof item.name === 'string' ? item.name : 'Untitled'}</h1>
+      </div>
+
+      <div className="item-detail">
+        {fields.map(f => {
+          const isEditing = editingCell?.fieldKey === f.key;
+          return (
+            <div
+              key={f.key}
+              className={`item-field-row${isEditing ? '' : ' item-field-row-clickable'}`}
+              onClick={isEditing ? undefined : () => startEdit(f.key, item[f.key])}
+            >
+              <span className="item-field-label">{f.name}</span>
+              {isEditing ? (
+                <input
+                  type="text"
+                  className="item-field-edit"
+                  autoFocus
+                  value={editValue}
+                  onChange={e => setEditValue(e.target.value)}
+                  onBlur={() => commitEdit(f.key)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') { e.currentTarget.blur(); }
+                    if (e.key === 'Escape') { cancelEdit.current = true; setEditingCell(null); }
+                  }}
+                />
+              ) : (
+                <span className="item-field-value">
+                  {String(item[f.key] ?? '')}
+                </span>
+              )}
+            </div>
+          );
+        })}
+        {newFieldForm !== null ? (
+          <div className="item-new-field-form">
+            <input
+              ref={newFieldInputRef}
+              type="text"
+              className="item-new-field-input"
+              placeholder="Field name"
+              autoComplete="off"
+              value={newFieldForm.name}
+              onChange={e => { setNewFieldForm({ name: e.target.value }); setAddFieldError(null); }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') submitNewField();
+                if (e.key === 'Escape') setNewFieldForm(null);
+              }}
+            />
+            {addFieldError && <span className="form-error">{addFieldError}</span>}
+            <button className="btn-icon btn-icon-small" onClick={() => setNewFieldForm(null)} title="Cancel">
+              <svg className="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <button className="btn-add-field" onClick={openNewFieldForm} title="Add field">
+            <svg className="icon-small" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M12 5v14M5 12h14"/>
+            </svg>
+            add field
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/list/src/style.css
+++ b/list/src/style.css
@@ -280,6 +280,11 @@ a:focus-visible {
     gap: 8px;
 }
 
+.item-row-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+}
 
 .item-row {
     background: white;
@@ -288,15 +293,27 @@ a:focus-visible {
     padding: 12px 16px;
     font-size: 15px;
     color: #2c3e50;
-    transition: border-color 0.2s;
+    transition: all 0.2s;
 }
 
-.item-row:hover {
+.item-row-link:hover .item-row {
     border-color: #ccc;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 .item-name {
     font-weight: 500;
+    display: block;
+    margin-bottom: 4px;
+}
+
+.item-preview-value {
+    display: block;
+    font-size: 13px;
+    color: #999;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .item-field-row {
@@ -380,6 +397,15 @@ a:focus-visible {
     color: #bbb;
 }
 
+/* ============================================================================
+   Item Detail View
+   ============================================================================ */
+
+.item-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
 
 /* ============================================================================
    Responsive
@@ -396,6 +422,19 @@ a:focus-visible {
 
     .header h1 {
         font-size: 24px;
+    }
+
+    .btn-icon {
+        width: 44px;
+        height: 44px;
+    }
+
+    .item-row {
+        padding: 14px 16px;
+    }
+
+    .item-name {
+        font-size: 16px;
     }
 }
 
@@ -414,5 +453,14 @@ a:focus-visible {
 
     .document-card h3 {
         font-size: 15px;
+    }
+
+    .btn-icon {
+        width: 44px;
+        height: 44px;
+    }
+
+    .item-row {
+        padding: 14px 16px;
     }
 }

--- a/list/tests/field-editing.spec.js
+++ b/list/tests/field-editing.spec.js
@@ -28,6 +28,11 @@ async function gotoCollectionView(page, slug) {
   await page.waitForSelector('.item-list:not(:has(.loading))');
 }
 
+async function gotoItemDetail(page, slug, itemId) {
+  await page.goto(`/list/#/collection/${slug}/item/${itemId}`);
+  await page.waitForSelector('.item-detail:not(:has(.loading))');
+}
+
 test.describe('List - Edit Field Value', () => {
   test.afterEach(async ({ request }) => {
     const res = await request.get('/api/list/data/').catch(() => null);
@@ -47,7 +52,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     const value = page.locator('.item-field-value', { hasText: 'High' });
     await expect(value).toBeVisible();
@@ -61,7 +66,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
 
@@ -77,7 +82,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
     await page.locator('.item-field-edit').fill('Critical');
@@ -94,7 +99,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
     await page.locator('.item-field-edit').fill('Critical');
@@ -117,7 +122,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
     await page.locator('.item-field-edit').fill('Medium');
@@ -133,7 +138,7 @@ test.describe('List - Edit Field Value', () => {
       [{ id: 'i1', name: 'Task A', priority: 'High' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
     await page.locator('.item-field-edit').fill('Critical');
@@ -157,12 +162,11 @@ test.describe('List - Edit Field Value', () => {
       ]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await page.locator('.item-field-value', { hasText: 'High' }).click();
 
     await expect(page.locator('.item-field-edit')).toHaveCount(1);
     await expect(page.locator('.item-field-edit')).toHaveValue('High');
-    await expect(page.locator('.item-field-value', { hasText: 'Low' })).toBeVisible();
   });
 });

--- a/list/tests/fields.spec.js
+++ b/list/tests/fields.spec.js
@@ -33,9 +33,14 @@ async function gotoCollectionView(page, slug) {
   await page.waitForSelector('.item-list:not(:has(.loading))');
 }
 
-// Click the "Add field" button on the first item card
+async function gotoItemDetail(page, slug, itemId) {
+  await page.goto(`/list/#/collection/${slug}/item/${itemId}`);
+  await page.waitForSelector('.item-detail:not(:has(.loading))');
+}
+
+// Click the "Add field" button on the item detail view
 async function clickAddField(page) {
-  await page.locator('.item-row button[title="Add field"]').first().click();
+  await page.locator('.item-detail button[title="Add field"]').click();
 }
 
 test.describe('List - Add Field', () => {
@@ -50,29 +55,29 @@ test.describe('List - Add Field', () => {
     }
   });
 
-  test('should show add-field button on item cards', async ({ request, page }) => {
+  test('should show add-field button on item detail view', async ({ request, page }) => {
     const name = TEST_PREFIX + 'headers-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
 
-    await expect(page.locator('.item-row button[title="Add field"]')).toBeVisible();
+    await expect(page.locator('.item-detail button[title="Add field"]')).toBeVisible();
   });
 
-  test('should not show add-field button when there are no items', async ({ request, page }) => {
+  test('should show add-field button on any item detail view', async ({ request, page }) => {
     const name = TEST_PREFIX + 'no-items-' + Date.now();
-    const slug = await createCollectionViaApi(request, name);
+    const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
 
-    await expect(page.locator('button[title="Add field"]')).not.toBeVisible();
+    await expect(page.locator('.item-detail button[title="Add field"]')).toBeVisible();
   });
 
   test('should open new-field form when add-field button is clicked', async ({ request, page }) => {
     const name = TEST_PREFIX + 'form-open-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
     await clickAddField(page);
 
     await expect(page.locator('.item-new-field-form')).toBeVisible();
@@ -83,7 +88,7 @@ test.describe('List - Add Field', () => {
     const name = TEST_PREFIX + 'form-esc-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
     await clickAddField(page);
     await expect(page.locator('.item-new-field-form')).toBeVisible();
 
@@ -95,7 +100,7 @@ test.describe('List - Add Field', () => {
     const name = TEST_PREFIX + 'add-text-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
     await clickAddField(page);
 
     await page.locator('.item-new-field-input').fill('Priority');
@@ -114,7 +119,7 @@ test.describe('List - Add Field', () => {
     const name = TEST_PREFIX + 'persist-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
     await clickAddField(page);
 
     await page.locator('.item-new-field-input').fill('Due Date');
@@ -137,7 +142,7 @@ test.describe('List - Add Field', () => {
       { id: 'item1', name: 'Existing Item' }
     ]);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'item1');
     await clickAddField(page);
 
     await page.locator('.item-new-field-input').fill('Status');
@@ -159,7 +164,7 @@ test.describe('List - Add Field', () => {
       { id: 'item1', name: 'Task One' }
     ]);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'item1');
     await clickAddField(page);
 
     await page.locator('.item-new-field-input').fill('Done');
@@ -179,15 +184,17 @@ test.describe('List - Add Field', () => {
     const name = TEST_PREFIX + 'new-item-defaults-' + Date.now();
     const slug = await createCollectionWithItem(request, name);
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'seed1');
 
-    // Add a field via the seed item's card
+    // Add a field via the item detail view
     await clickAddField(page);
     await page.locator('.item-new-field-input').fill('Notes');
     await page.locator('.item-new-field-input').press('Enter');
     await expect(page.locator('.item-new-field-form')).not.toBeVisible();
 
-    // Now add a new item
+    // Go back to collection and add a new item
+    await page.goto(`/list/#/collection/${slug}`);
+    await page.waitForSelector('.item-list:not(:has(.loading))');
     await page.locator('button[title="New item"]').click();
     await page.locator('input.new-doc-input').fill('New Task');
     await page.locator('input.new-doc-input').press('Enter');
@@ -204,7 +211,7 @@ test.describe('List - Add Field', () => {
     expect(newItem[fieldKey]).toBe('');
   });
 
-  test('should display field labels and values in item cards', async ({ request, page }) => {
+  test('should display field labels and values in item detail view', async ({ request, page }) => {
     const name = TEST_PREFIX + 'load-fields-' + Date.now();
     const slug = nameToSlug(name);
 
@@ -225,13 +232,13 @@ test.describe('List - Add Field', () => {
       ])
     });
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await expect(page.locator('.item-field-label', { hasText: 'Priority' })).toBeVisible();
     await expect(page.locator('.item-field-label', { hasText: 'Status' })).toBeVisible();
   });
 
-  test('should display field values in item cards', async ({ request, page }) => {
+  test('should display field values in item detail view', async ({ request, page }) => {
     const name = TEST_PREFIX + 'display-vals-' + Date.now();
     const slug = nameToSlug(name);
 
@@ -249,7 +256,7 @@ test.describe('List - Add Field', () => {
       ])
     });
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'i1');
 
     await expect(page.locator('.item-field-value', { hasText: 'High' })).toBeVisible();
   });
@@ -261,7 +268,7 @@ test.describe('List - Add Field', () => {
       [{ id: 'item1', name: 'Task One', priority: '' }]
     );
 
-    await gotoCollectionView(page, slug);
+    await gotoItemDetail(page, slug, 'item1');
 
     await clickAddField(page);
     await page.locator('.item-new-field-input').fill('Priority');


### PR DESCRIPTION
## Summary

- **Compact list view**: `CollectionView` now renders items as minimal tap-targets — item name plus up to two field values as a preview. Each card links to the new detail route.
- **Item detail view**: New `ItemDetail` component at `/collection/:slug/item/:id` shows all fields with inline editing (click → edit, Enter/blur → save, Escape → cancel) and the add-field form, moved here from the list view.
- **Mobile CSS**: `btn-icon` grows to 44×44px touch targets on `< 768px`; item cards get extra padding; hover shows soft box-shadow elevation instead of border colour change.
- **Performance**: `loadData` in both components now fetches schema and items in parallel via `Promise.all`.
- **Tests**: `field-editing.spec.js` and `fields.spec.js` updated to navigate to the item detail view before interacting with fields. All 50 Playwright tests pass.

## Test plan

- [ ] Create a collection and add items — list should show compact cards (name + first 2 field values)
- [ ] Click a card — should navigate to `/collection/:slug/item/:id`
- [ ] Edit a field in the detail view — change persists after reload
- [ ] Add a new field in the detail view — field appears for all items
- [ ] Back button from detail returns to collection list
- [ ] On a narrow viewport (< 768px) — cards are comfortable, buttons are ≥ 44px tap targets
- [ ] `cd list && npm test` — all 50 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)