### PR TITLE
feat(skills): add implement-story skill

### DIFF
--- a/.claude/skills/implement-story/SKILL.md
+++ b/.claude/skills/implement-story/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: implement-story
+description: Implement a user story end-to-end — write the code, run existing tests, add new tests if needed, self-review the diff, then commit. Use when the user wants to take a single user story (or GitHub issue title) from backlog to committed code.
+argument-hint: "<story description or issue number>"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, TaskCreate, TaskUpdate
+---
+
+# Implement a User Story
+
+Implement the user story or feature described in **$ARGUMENTS** end-to-end.
+
+## Step 1 — Understand the story
+
+If `$ARGUMENTS` looks like an issue number, fetch it with `gh issue view $ARGUMENTS` to get full details.
+
+Otherwise treat `$ARGUMENTS` as the story description directly.
+
+Identify:
+- What the user can do after this story is done (the acceptance criteria)
+- Which app directory is affected (`write/`, `list/`, `agenda/`, `show/`)
+- Which files are likely to change
+
+Read the relevant source files before proposing any changes. Do not modify code you have not read.
+
+## Step 2 — Plan
+
+Write a short bullet-list implementation plan (5–10 bullets). Include:
+- Files to create or change and why
+- Any new types, hooks, or components needed
+- How the feature will be tested
+
+Show the plan to the user and wait for approval before proceeding.
+
+## Step 3 — Implement
+
+Make the changes described in the plan.
+
+Rules:
+- Follow the patterns already in the codebase (hash routing, `useStorage()`, existing component structure).
+- Do not add features, error handling, or abstractions beyond what the story requires.
+- Do not add comments unless the logic is non-obvious.
+- Keep diffs small and focused.
+
+## Step 4 — Run tests
+
+From the affected app directory, run:
+
+```bash
+npm test
+```
+
+If tests fail:
+1. Read the failure output carefully.
+2. Fix the root cause — do not skip or comment out failing tests.
+3. Re-run until green.
+
+If the story adds new user-visible behaviour, add at least one Playwright test in `<app>/tests/` covering the happy path. Follow the style of existing test files in that directory.
+
+## Step 5 — Self-review
+
+Run `git diff` and review every changed line.
+
+Check:
+- No dead code, debug logs, or commented-out blocks left behind.
+- No unrelated files touched.
+- Acceptance criteria from Step 1 are met.
+- Code follows UI Guidelines (`docs/UI-GUIDELINES.md`) if any UI was changed.
+
+Fix anything found before committing. If nothing needs fixing, state that explicitly.
+
+## Step 6 — Commit
+
+Stage only the files changed for this story. Commit with a conventional commit message:
+
+```
+<type>(<scope>): <short imperative description>
+```
+
+Where:
+- `type` is one of `feat`, `fix`, `refactor`, `test`, `docs`
+- `scope` is the app name (e.g. `list`, `write`)
+- Description is ≤ 72 characters, imperative mood
+
+Example: `feat(list): add delete item button with confirmation`
+
+Do **not** push unless the user explicitly asks.
+
+## Step 7 — Report
+
+Tell the user:
+- What was implemented (1–3 sentences)
+- Which files changed
+- Test result (pass count or "no existing tests; added N new tests")
+- The commit hash

--- a/show/REQUIREMENTS.md
+++ b/show/REQUIREMENTS.md
@@ -1,0 +1,193 @@
+# Show Requirements
+
+## Overview
+
+A modern presentation tool built around a **timeline of slides** — a linear sequence of focused moments, each with a clear message. Show odbacuje model "bullet-point slajdova" iz legacy softvera (PowerPoint, Keynote) i daje korisniku alat koji naglašava sadržaj i vizuelni utisak. Radi na Fleabox serveru i čuva prezentacije kao JSON fajlove.
+
+## Presentations (Home Screen)
+
+- Korisnik vidi sve svoje prezentacije kao kartice (naziv, broj slajdova, datum izmene)
+- Kreiranje nove prezentacije (unosi naziv)
+- Preimenovanje prezentacije
+- Brisanje prezentacije (sa potvrdom)
+- Otvaranje prezentacije u editoru
+
+## Timeline Model
+
+- Svaka prezentacija je **linearna sekvenca slajdova** — timeline
+- Slajdovi se prikazuju i prezentuju redom, od prvog do poslednjeg
+- Editor prikazuje slajdove kao horizontalni ili vertikalni niz (thumbnail prikaz)
+- Korisnik može da doda, obriše, pomeri i duplicira slajdove
+
+## Slides
+
+Svaki slajd ima:
+- **Layout** — jedan od unapred definisanih rasporeda elemenata
+- **Content blocks** — sadržaj koji popunjava layout
+- **Tema** — nasleđuje temu prezentacije (može se overridovati po slajdu)
+- **Speaker notes** — beleške za predavača, nevidljive publici
+
+## Layouts
+
+Korisnik bira layout pri kreiranju slajda. Layouti su fiksirani — nema slobodnog pozicioniranja elemenata.
+
+| Layout | Opis |
+|--------|------|
+| `title` | Veliki naslov + opcioni podnaslov, centrirano |
+| `statement` | Jedna snažna izjava, full-bleed tekst |
+| `text` | Naslov + paragraf teksta |
+| `image` | Full-bleed slika + opcioni natpis |
+| `image-text` | Slika s jedne strane, tekst s druge |
+| `quote` | Citat + atribucija |
+| `list` | Naslov + kratka lista (max 5 stavki — enforced) |
+| `code` | Naslov + code block sa syntax highlightingom |
+| `chart` | Naslov + grafikon (bar, line ili pie) |
+| `table` | Naslov + tabela sa podacima |
+| `video` | Embedded video (URL) ili uploaded fajl |
+| `blank` | Prazno platno bez predefinisanih zona |
+
+## Content Types
+
+Svaki content block je direktno editabilan u editoru:
+
+| Tip | Detalji |
+|-----|---------|
+| **Naslov / tekst** | Plain text; bold i italic putem Markdown sintakse |
+| **Bullet lista** | Max 5 stavki (enforced) |
+| **Slika** | Upload sa uređaja; čuva se via Fleabox API |
+| **Video** | URL (YouTube, Vimeo) ili upload video fajla |
+| **Audio** | URL ili upload audio fajla |
+| **Grafikon** | Bar, line, pie — podaci se unose direktno u aplikaciji |
+| **Tabela** | Korisnik definiše redove i kolone, unosi podatke |
+| **Code block** | Unos koda, bira se programski jezik za syntax highlighting |
+| **Citat** | Tekst citata + polje za atribuciju |
+
+## Themes
+
+- Tema se postavlja na nivou prezentacije
+- Može se overridovati na nivou pojedinačnog slajda
+- Korisnik bira jednu od unapred definisanih tema (ne može da kreira sopstvene u v1)
+- Tema kontroliše: boje pozadine i teksta, tipografiju (fontove), raspored elemenata unutar layouta
+
+| Tema | Opis |
+|------|------|
+| `minimal` | Bela pozadina, tamni tekst, čisti sans-serif (default) |
+| `dark` | Tamna pozadina, svetli tekst |
+| `warm` | Kremasta pozadina, topli tonovi |
+| `bold` | Jarke boje, naglašena tipografija |
+| `nature` | Zeleni i zemljani tonovi |
+
+## Editor
+
+- **Levi panel**: thumbnail lista slajdova (timeline prikaz)
+- **Centralni deo**: WYSIWYG editing aktivnog slajda
+- **Desni panel**: opcije slajda (layout picker, tema override, speaker notes)
+- Dodavanje novog slajda: bira se layout iz pickera
+- Reorder slajdova: drag-and-drop u lijevom panelu
+- Duplikanje i brisanje slajdova
+- Auto-save: debounced, 2 sekunde nakon poslednje izmene
+- Ručni save (dugme ili Ctrl+S)
+- Undo/Redo (u okviru sesije)
+
+## Presenter Mode
+
+- Fullscreen prikaz slajda za publiku
+- Navigacija napred/nazad:
+  - Tastatura (strelice, space)
+  - Swipe gesta (mobilni/tablet)
+  - On-screen dugmad
+- Speaker notes prikazane u odvojenom, manjem delu ekrana (vidljive samo predavaču)
+- Brojač slajdova (npr. "3 / 12")
+- Izlaz iz presenter mode vraća korisnika na editor, na trenutni slajd
+
+## Export
+
+- Export prezentacije u **PDF** (jedan slajd = jedna stranica)
+- Export čuva vizuelni prikaz slajdova (tema, layout, sadržaj)
+- Speaker notes nisu uključene u PDF (opcija za uključivanje u v2)
+
+## Data Storage
+
+Prezentacije se čuvaju kao JSON fajlovi:
+```
+/api/show/data/<presentation-slug>.json
+```
+
+Uploadovani fajlovi (slike, video, audio) čuvaju se pored JSON fajla:
+```
+/api/show/data/<presentation-slug>-<timestamp>-<filename>
+```
+
+### JSON struktura
+
+```json
+{
+  "id": "my-presentation",
+  "title": "My Presentation",
+  "theme": "minimal",
+  "created": "2026-04-08T10:00:00Z",
+  "modified": "2026-04-08T12:30:00Z",
+  "slides": [
+    {
+      "id": "slide-1",
+      "layout": "title",
+      "themeOverride": null,
+      "content": {
+        "title": "Dobrodošli",
+        "subtitle": "Uvod u novu eru prezentacija"
+      },
+      "notes": "Predstavi se publici."
+    }
+  ]
+}
+```
+
+## Fleabox API
+
+| Operacija | Metod | Putanja |
+|-----------|-------|---------|
+| Lista prezentacija | `GET` | `/api/show/data/` |
+| Učitaj prezentaciju | `GET` | `/api/show/data/<slug>.json` |
+| Sačuvaj prezentaciju | `PUT` | `/api/show/data/<slug>.json` |
+| Obriši prezentaciju | `DELETE` | `/api/show/data/<slug>.json` |
+| Upload fajla | `PUT` | `/api/show/data/<slug>-<ts>-<file>` |
+
+## URL Structure
+
+Hash-based routing (kao Write app):
+
+| Pogled | URL |
+|--------|-----|
+| Home (lista prezentacija) | `/show/#/` |
+| Editor | `/show/#/editor/<slug>` |
+| Presenter mode | `/show/#/present/<slug>` |
+| Presenter mode na slajdu N | `/show/#/present/<slug>/<n>` |
+
+## UI & Design
+
+Prati Fleaoffice UI Guidelines:
+- Mobile-first, responsive (desktop i mobilni)
+- 8px spacing grid
+- Minimalan chrome — sadržaj je u prvom planu
+- Suptilne tranzicije (150–250ms)
+- Touch targeti min 44×44px
+- Light/dark mode prati `prefers-color-scheme` sistemsko podešavanje
+
+## Technical Stack
+
+Konzistentno sa ostatkom Fleaoffice suite:
+- **React 19** + **TypeScript**
+- **Vite** (base path: `/show/`)
+- **React Router** (hash-based)
+- `useStorage()` hook za sve API pozive (isti pattern kao Write app)
+- Bez eksternih UI biblioteka
+
+## Out of Scope (v1)
+
+- Export u PPTX ili druge formate
+- Deljenje prezentacija sa drugim korisnicima
+- Real-time kolaboracija
+- Animacije između slajdova (osim jednostavnog fade-a)
+- Kreiranje sopstvenih tema
+- Speaker notes u PDF exportu
+- Offline rad bez Fleabox servera

--- a/show/USER-STORIES.md
+++ b/show/USER-STORIES.md
@@ -1,0 +1,119 @@
+# Show — User Stories
+
+## P1 — MVP
+
+Cilj: korisnik može da napravi i prezentuje jednostavnu prezentaciju.
+
+### Home Screen
+
+- as a user I want to see all my presentations on a home screen so that I can manage them
+- as a user I want to see the title, slide count, and last modified date for each presentation so that I can quickly identify what I'm looking for
+- as a user I want to create a new presentation by entering a title so that I can start building content
+- as a user I want to rename a presentation so that I can keep my work organized
+- as a user I want to delete a presentation with confirmation so that I don't accidentally lose my work
+- as a user I want to open a presentation in the editor so that I can view and edit its slides
+
+### Editor
+
+- as a user I want to see a timeline of slide thumbnails so that I can understand the structure of my presentation
+- as a user I want to click a slide in the timeline so that I can jump to editing it
+- as a user I want to add a new slide by choosing a layout so that I can build my presentation step by step
+- as a user I want to choose from a set of predefined layouts when adding a slide so that my content is well-structured
+- as a user I want to duplicate a slide so that I can reuse a layout or content without retyping
+- as a user I want to delete a slide with confirmation so that I don't accidentally remove content
+- as a user I want my changes to be auto-saved after 2 seconds of inactivity so that I don't lose work
+- as a user I want to manually save at any time so that I can control when changes are persisted
+- as a user I want to return to the home screen from the editor so that I can switch presentations
+
+### Layouts
+
+- as a user I want a title layout so that I can create a cover or section header slide
+- as a user I want a statement layout so that I can present a single bold message
+- as a user I want a text layout so that I can combine a heading with a body paragraph
+- as a user I want an image layout so that I can fill a slide with a visual
+- as a user I want a quote layout so that I can highlight a citation with attribution
+- as a user I want a list layout so that I can present a short set of key points
+- as a user I want the list layout to enforce a maximum of 5 items so that I avoid overloading my audience
+
+### Content Editing
+
+- as a user I want to edit text directly on the slide so that editing feels natural and immediate
+- as a user I want to use Markdown syntax for bold and italic so that I can format text without leaving the keyboard
+- as a user I want to upload an image from my device so that I can include my own visuals
+- as a user I want to enter a quote and its attribution so that citations are clearly presented
+
+### Themes
+
+- as a user I want a minimal theme applied by default so that my presentation looks clean without any configuration
+- as a user I want the app to follow my system light/dark mode preference so that the editor is comfortable to use
+
+### Presenter Mode
+
+- as a user I want to enter fullscreen presenter mode so that my audience only sees the slides
+- as a user I want to navigate slides with keyboard arrow keys so that I can present without touching the screen
+- as a user I want to navigate slides with on-screen buttons so that I can present on a touch device
+- as a user I want to swipe to navigate slides on mobile so that presenting feels natural on a phone or tablet
+- as a user I want to see a slide counter (e.g. "3 / 12") so that I know where I am in the presentation
+- as a user I want to exit presenter mode and return to the editor at the current slide so that I can make quick fixes mid-presentation
+
+---
+
+## P2 — Kompletna aplikacija
+
+Cilj: punopravna zamena za PowerPoint za većinu slučajeva.
+
+### Editor
+
+- as a user I want to reorder slides by drag-and-drop so that I can restructure my presentation easily
+- as a user I want undo and redo within a session so that I can recover from mistakes
+
+### Layouts
+
+- as a user I want an image-text layout so that I can pair a visual with an explanation
+- as a user I want a code layout so that I can present code with syntax highlighting
+- as a user I want a blank layout so that I have full control over an empty canvas
+
+### Content Editing
+
+- as a user I want to add a video by URL (YouTube, Vimeo) so that I can embed online content
+- as a user I want to enter code and select a programming language so that syntax highlighting is applied correctly
+- as a user I want to define rows and columns for a table and enter data so that I can present structured information
+
+### Themes
+
+- as a user I want to set a theme for my presentation so that all slides have a consistent visual style
+- as a user I want to choose from predefined themes (minimal, dark, warm, bold, nature) so that I can match the mood of my content
+- as a user I want a theme to control colors, fonts, and layout of elements so that I don't have to style slides manually
+- as a user I want to override the theme on a single slide so that I can create visual contrast for key moments
+
+### Speaker Notes
+
+- as a user I want to add speaker notes to each slide so that I have prompts during my presentation
+- as a user I want speaker notes to be hidden from the audience in presenter mode so that only I can see them
+- as a user I want to see my speaker notes while in presenter mode so that I can follow my talking points
+
+---
+
+## P3 — Nice to have
+
+Cilj: napredno i kompletno.
+
+### Layouts
+
+- as a user I want a chart layout so that I can visualize data directly in a slide
+- as a user I want a video layout so that I can embed or upload a video into a slide
+
+### Content Editing
+
+- as a user I want to enter data for a bar chart so that I can visualize comparisons
+- as a user I want to enter data for a line chart so that I can show trends
+- as a user I want to enter data for a pie chart so that I can show proportions
+- as a user I want to upload a video file so that I can include local video content
+- as a user I want to upload an audio file so that I can include sound in my presentation
+- as a user I want to add audio by URL so that I can link to online audio content
+
+### Export
+
+- as a user I want to export my presentation as a PDF so that I can share or print it
+- as a user I want each slide to appear as a separate page in the PDF so that the layout is preserved
+- as a user I want the PDF to reflect the current theme and content so that the exported file looks like the presentation


### PR DESCRIPTION
## Summary

- Adds new Claude Code skill `/implement-story` at `.claude/skills/implement-story/SKILL.md`
- Skill takes a user story description or GitHub issue number and delivers it end-to-end: plan → implement → test → self-review → commit
- Follows project conventions (hash routing, `useStorage()`, existing patterns)

## How to use

```
/implement-story "As a user I can mark a task as done"
/implement-story 42   # GitHub issue number
```

## Skill steps

1. Understand the story (reads issue or text, identifies acceptance criteria)
2. Plan (bullet list, waits for approval)
3. Implement (follows existing codebase patterns)
4. Test (`npm test`, adds Playwright test for new behaviour)
5. Self-review (`git diff` check)
6. Commit (conventional commit, no push)
7. Report (summary of what changed)

## Test plan

- [ ] Run `/implement-story` with a story description and verify it produces a plan before touching code
- [ ] Verify it runs `npm test` after implementation
- [ ] Verify the commit message follows the conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)