### PR TITLE
feat(list): add currency field type with configurable symbol

### DIFF
--- a/list/src/CollectionView.tsx
+++ b/list/src/CollectionView.tsx
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import { useStorage } from './storage';
 import { Item, generateId } from './Item';
 import { nameToSlug } from './slug';
-import { type FieldDraft, type Field, fieldDefault, parseFieldValue } from './field';
+import { type FieldDraft, type Field, fieldDefault, parseFieldValue, formatFieldValue, fieldInputType, fieldInputStep } from './field';
 
 interface Schema {
   name: string;
@@ -104,6 +104,8 @@ export function CollectionView() {
       newField = { key, name, type: 'number', mode: newFieldForm.mode };
     } else if (newFieldForm.type === 'checkbox') {
       newField = { key, name, type: 'checkbox' };
+    } else if (newFieldForm.type === 'currency') {
+      newField = { key, name, type: 'currency', symbol: newFieldForm.symbol };
     } else {
       newField = { key, name, type: 'text' };
     }
@@ -126,7 +128,11 @@ export function CollectionView() {
 
   function startEdit(itemId: string, fieldKey: string, currentValue: unknown) {
     setEditingCell({ itemId, fieldKey });
-    setEditValue(String(currentValue ?? ''));
+    const field = fields.find(f => f.key === fieldKey);
+    const raw = (field?.type === 'currency' && typeof currentValue === 'number')
+      ? String(currentValue)
+      : String(currentValue ?? '');
+    setEditValue(raw);
     cancelEdit.current = false;
   }
 
@@ -165,8 +171,8 @@ export function CollectionView() {
               <span className="item-field-label">{f.name}</span>
               {isEditing ? (
                 <input
-                  type={f.type}
-                  step={f.type === 'number' && f.mode === 'decimal' ? 'any' : undefined}
+                  type={fieldInputType(f)}
+                  step={fieldInputStep(f)}
                   className="item-field-edit"
                   autoFocus
                   value={editValue}
@@ -179,7 +185,7 @@ export function CollectionView() {
                 />
               ) : (
                 <span className="item-field-value">
-                  {String(item[f.key] ?? '')}
+                  {formatFieldValue(item[f.key], f)}
                 </span>
               )}
             </div>
@@ -204,14 +210,17 @@ export function CollectionView() {
               className="item-new-field-type"
               value={newFieldForm.type}
               onChange={e => {
-                const t = e.target.value as 'text' | 'number';
-                setNewFieldForm(t === 'number'
-                  ? { name: newFieldForm.name, type: 'number', mode: 'integer' }
-                  : { name: newFieldForm.name, type: t });
+                const t = e.target.value as FieldDraft['type'];
+                switch (t) {
+                  case 'number': setNewFieldForm({ name: newFieldForm.name, type: 'number', mode: 'integer' }); break;
+                  case 'currency': setNewFieldForm({ name: newFieldForm.name, type: 'currency', symbol: '$' }); break;
+                  default: setNewFieldForm({ name: newFieldForm.name, type: t });
+                }
               }}
             >
               <option value="text">text</option>
               <option value="number">number</option>
+              <option value="currency">currency</option>
             </select>
             {newFieldForm.type === 'number' && (
               <select
@@ -226,6 +235,16 @@ export function CollectionView() {
                 <option value="integer">integer</option>
                 <option value="decimal">decimal</option>
               </select>
+            )}
+            {newFieldForm.type === 'currency' && (
+              <input
+                type="text"
+                className="item-new-field-symbol"
+                value={newFieldForm.symbol}
+                onChange={e => setNewFieldForm({ name: newFieldForm.name, type: 'currency', symbol: e.target.value })}
+                maxLength={3}
+                aria-label="Currency symbol"
+              />
             )}
             {index === 0 && addFieldError && <span className="form-error">{addFieldError}</span>}
             <button className="btn-icon btn-icon-small" onClick={() => setNewFieldForm(null)} title="Cancel">

--- a/list/src/field.integration.test.ts
+++ b/list/src/field.integration.test.ts
@@ -150,3 +150,60 @@ describe('editing a text field keeps value as string', () => {
     expect(updated[0].notes).toBe('hello world');
   });
 });
+
+describe('adding a currency field backfills existing items with 0', () => {
+  const existingItems: Item[] = [
+    { id: 'a', name: 'Alpha' },
+    { id: 'b', name: 'Beta', qty: 3 },
+  ];
+
+  const newField: Field = { key: 'price', name: 'Price', type: 'currency', symbol: '$' };
+  const defaultValue = fieldDefault(newField);
+  const updatedItems = existingItems.map(item => ({ ...item, [newField.key]: defaultValue }));
+
+  it('adds the field key to every item', () => {
+    expect(updatedItems.every(i => 'price' in i)).toBe(true);
+  });
+
+  it('sets the default to 0 (number, not string)', () => {
+    expect(updatedItems[0].price).toBe(0);
+    expect(typeof updatedItems[0].price).toBe('number');
+  });
+
+  it('preserves existing fields on items', () => {
+    expect(updatedItems[1].qty).toBe(3);
+  });
+});
+
+describe('editing a currency field stores a float', () => {
+  const item: Item = { id: 'a', name: 'Alpha', price: 0 };
+  const field: Field = { key: 'price', name: 'Price', type: 'currency', symbol: '$' };
+
+  it('stores the parsed float', () => {
+    const updated = [item].map(i => ({ ...i, price: parseFieldValue('19.99', field) }));
+    expect(updated[0].price).toBeCloseTo(19.99);
+    expect(typeof updated[0].price).toBe('number');
+  });
+
+  it('stores 0 when input is cleared', () => {
+    const updated = [item].map(i => ({ ...i, price: parseFieldValue('', field) }));
+    expect(updated[0].price).toBe(0);
+  });
+});
+
+describe('new item gets correct defaults including currency field', () => {
+  const fields: Field[] = [
+    { key: 'qty',   name: 'Qty',   type: 'number',   mode: 'integer' },
+    { key: 'price', name: 'Price', type: 'currency', symbol: '$' },
+    { key: 'notes', name: 'Notes', type: 'text' },
+  ];
+
+  const defaults: Record<string, unknown> = {};
+  for (const f of fields) defaults[f.key] = fieldDefault(f);
+  const newItem: Item = { id: 'x', name: 'New Item', ...defaults };
+
+  it('currency field defaults to 0', () => {
+    expect(newItem.price).toBe(0);
+    expect(typeof newItem.price).toBe('number');
+  });
+});

--- a/list/src/field.test.ts
+++ b/list/src/field.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fieldDefault, parseFieldValue } from './field';
+import { fieldDefault, parseFieldValue, formatFieldValue, fieldInputType, fieldInputStep } from './field';
 import type { Field } from './field';
 
 // ---------------------------------------------------------------------------
@@ -21,6 +21,10 @@ describe('fieldDefault', () => {
 
   it('returns 0 for decimal number fields', () => {
     expect(fieldDefault({ name: 'Price', type: 'number', mode: 'decimal' })).toBe(0);
+  });
+
+  it('returns 0 for currency fields', () => {
+    expect(fieldDefault({ name: 'Price', type: 'currency', symbol: '$' })).toBe(0);
   });
 });
 
@@ -113,5 +117,126 @@ describe('parseFieldValue — number (decimal)', () => {
 
   it('returns a number type (not string)', () => {
     expect(typeof parseFieldValue('3.14', field)).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFieldValue — currency fields
+// ---------------------------------------------------------------------------
+
+describe('parseFieldValue — currency', () => {
+  const field: Field = { key: 'price', name: 'Price', type: 'currency', symbol: '$' };
+
+  it('parses a decimal string to a number', () => {
+    expect(parseFieldValue('9.99', field)).toBeCloseTo(9.99);
+  });
+
+  it('parses a whole number string to a number', () => {
+    expect(parseFieldValue('42', field)).toBe(42);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(parseFieldValue('', field)).toBe(0);
+  });
+
+  it('returns 0 for non-numeric string', () => {
+    expect(parseFieldValue('abc', field)).toBe(0);
+  });
+
+  it('parses negative values', () => {
+    expect(parseFieldValue('-1.50', field)).toBeCloseTo(-1.5);
+  });
+
+  it('returns a number type (not string)', () => {
+    expect(typeof parseFieldValue('9.99', field)).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFieldValue
+// ---------------------------------------------------------------------------
+
+describe('formatFieldValue — currency', () => {
+  const field: Field = { key: 'price', name: 'Price', type: 'currency', symbol: '$' };
+
+  it('formats a number with symbol prefix and 2 decimal places', () => {
+    expect(formatFieldValue(9.99, field)).toBe('$9.99');
+  });
+
+  it('formats zero as $0.00', () => {
+    expect(formatFieldValue(0, field)).toBe('$0.00');
+  });
+
+  it('pads whole numbers to 2 decimal places', () => {
+    expect(formatFieldValue(42, field)).toBe('$42.00');
+  });
+
+  it('uses the configured symbol', () => {
+    const euro: Field = { key: 'price', name: 'Price', type: 'currency', symbol: '€' };
+    expect(formatFieldValue(9.99, euro)).toBe('€9.99');
+  });
+
+  it('handles non-number stored value gracefully', () => {
+    expect(formatFieldValue(null, field)).toBe('$0.00');
+  });
+});
+
+describe('formatFieldValue — text passthrough', () => {
+  const field: Field = { key: 'notes', name: 'Notes', type: 'text' };
+
+  it('returns the string value unchanged', () => {
+    expect(formatFieldValue('hello', field)).toBe('hello');
+  });
+
+  it('returns empty string for null', () => {
+    expect(formatFieldValue(null, field)).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fieldInputType
+// ---------------------------------------------------------------------------
+
+describe('fieldInputType', () => {
+  it('returns "text" for text fields', () => {
+    expect(fieldInputType({ key: 'n', name: 'N', type: 'text' })).toBe('text');
+  });
+
+  it('returns "number" for integer number fields', () => {
+    expect(fieldInputType({ key: 'n', name: 'N', type: 'number', mode: 'integer' })).toBe('number');
+  });
+
+  it('returns "number" for decimal number fields', () => {
+    expect(fieldInputType({ key: 'n', name: 'N', type: 'number', mode: 'decimal' })).toBe('number');
+  });
+
+  it('returns "number" for currency fields', () => {
+    expect(fieldInputType({ key: 'n', name: 'N', type: 'currency', symbol: '$' })).toBe('number');
+  });
+
+  it('returns "checkbox" for checkbox fields', () => {
+    expect(fieldInputType({ key: 'n', name: 'N', type: 'checkbox' })).toBe('checkbox');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fieldInputStep
+// ---------------------------------------------------------------------------
+
+describe('fieldInputStep', () => {
+  it('returns undefined for integer number fields', () => {
+    expect(fieldInputStep({ key: 'n', name: 'N', type: 'number', mode: 'integer' })).toBeUndefined();
+  });
+
+  it('returns "any" for decimal number fields', () => {
+    expect(fieldInputStep({ key: 'n', name: 'N', type: 'number', mode: 'decimal' })).toBe('any');
+  });
+
+  it('returns "any" for currency fields', () => {
+    expect(fieldInputStep({ key: 'n', name: 'N', type: 'currency', symbol: '$' })).toBe('any');
+  });
+
+  it('returns undefined for text fields', () => {
+    expect(fieldInputStep({ key: 'n', name: 'N', type: 'text' })).toBeUndefined();
   });
 });

--- a/list/src/field.ts
+++ b/list/src/field.ts
@@ -1,7 +1,8 @@
 export type FieldDraft =
   | { name: string; type: 'text' }
   | { name: string; type: 'number'; mode: 'integer' | 'decimal' }
-  | { name: string; type: 'checkbox' };
+  | { name: string; type: 'checkbox' }
+  | { name: string; type: 'currency'; symbol: string };
 
 export type Field = FieldDraft & { key: string };
 
@@ -9,6 +10,7 @@ export type Field = FieldDraft & { key: string };
 export function fieldDefault(field: FieldDraft): unknown {
   if (field.type === 'checkbox') return false;
   if (field.type === 'number') return 0;
+  if (field.type === 'currency') return 0;
   return '';
 }
 
@@ -23,5 +25,37 @@ export function parseFieldValue(raw: string, field: Field): unknown {
       return isNaN(n) ? 0 : n;
     }
   }
+  if (field.type === 'currency') {
+    const n = parseFloat(raw);
+    return isNaN(n) ? 0 : n;
+  }
   return raw;
+}
+
+/** Return the HTML input type to use when editing a field value. */
+export function fieldInputType(field: Field): string {
+  switch (field.type) {
+    case 'number':
+    case 'currency': return 'number';
+    default: return field.type;
+  }
+}
+
+/** Return the step attribute for a numeric input, or undefined if not applicable. */
+export function fieldInputStep(field: Field): string | undefined {
+  switch (field.type) {
+    case 'currency': return 'any';
+    case 'number': return field.mode === 'decimal' ? 'any' : undefined;
+    default: return undefined;
+  }
+}
+
+/** Format a stored field value for display. */
+export function formatFieldValue(value: unknown, field: Field): string {
+  if (field.type === 'currency') {
+    const n = typeof value === 'number' ? value : parseFloat(String(value));
+    const formatted = isNaN(n) ? '0.00' : n.toFixed(2);
+    return `${field.symbol}${formatted}`;
+  }
+  return String(value ?? '');
 }

--- a/list/src/style.css
+++ b/list/src/style.css
@@ -381,7 +381,8 @@ a:focus-visible {
 }
 
 .item-new-field-type,
-.item-new-field-mode {
+.item-new-field-mode,
+.item-new-field-symbol {
     font-size: 13px;
     color: #2c3e50;
     background: transparent;
@@ -390,6 +391,12 @@ a:focus-visible {
     padding: 2px 0;
     cursor: pointer;
     outline: none;
+}
+
+.item-new-field-symbol {
+    width: 2.5em;
+    text-align: center;
+    cursor: text;
 }
 
 /* ============================================================================

--- a/list/tests/currency-field.spec.js
+++ b/list/tests/currency-field.spec.js
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test';
+
+const TEST_PREFIX = 'currency-field-test-';
+
+function nameToSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 100);
+}
+
+async function createCollectionViaApi(request, name, fields = [], items = []) {
+  const slug = nameToSlug(name);
+  await request.put(`/api/list/data/${slug}/schema.json`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify({ name, fields })
+  });
+  await request.put(`/api/list/data/${slug}/items.json`, {
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(items)
+  });
+  return slug;
+}
+
+async function createCollectionWithItem(request, name, fields = []) {
+  return createCollectionViaApi(request, name, fields, [{ id: 'seed1', name: 'Seed Item' }]);
+}
+
+async function deleteCollectionViaApi(request, slug) {
+  await request.delete(`/api/list/data/${slug}?recursive=true`).catch(() => {});
+}
+
+async function gotoCollectionView(page, slug) {
+  await page.goto(`/list/#/collection/${slug}`);
+  await page.waitForSelector('.item-list:not(:has(.loading))');
+}
+
+async function clickAddField(page) {
+  await page.locator('.item-row button[title="Add field"]').first().click();
+}
+
+test.describe('List - Currency Field', () => {
+  test.afterEach(async ({ request }) => {
+    const res = await request.get('/api/list/data/').catch(() => null);
+    if (!res?.ok()) return;
+    const entries = await res.json().catch(() => []);
+    for (const entry of entries) {
+      if (entry.type === 'dir' && entry.name.startsWith(TEST_PREFIX)) {
+        await deleteCollectionViaApi(request, entry.name);
+      }
+    }
+  });
+
+  test('should show currency option in the type selector', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'type-opt-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await expect(page.locator('.item-new-field-type option[value="currency"]')).toBeAttached();
+  });
+
+  test('should show symbol input only when type is currency', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'symbol-show-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await expect(page.locator('.item-new-field-symbol')).not.toBeVisible();
+
+    await page.locator('.item-new-field-type').selectOption('currency');
+    await expect(page.locator('.item-new-field-symbol')).toBeVisible();
+    await expect(page.locator('.item-new-field-symbol')).toHaveValue('$');
+  });
+
+  test('should hide mode selector when type is currency', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'no-mode-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-type').selectOption('currency');
+    await expect(page.locator('.item-new-field-mode')).not.toBeVisible();
+  });
+
+  test('should persist currency field with symbol in schema.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'schema-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Price');
+    await page.locator('.item-new-field-type').selectOption('currency');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
+
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(schema.fields).toHaveLength(1);
+    expect(schema.fields[0].name).toBe('Price');
+    expect(schema.fields[0].type).toBe('currency');
+    expect(schema.fields[0].symbol).toBe('$');
+  });
+
+  test('should persist custom symbol in schema.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'custom-sym-' + Date.now();
+    const slug = await createCollectionWithItem(request, name);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Cost');
+    await page.locator('.item-new-field-type').selectOption('currency');
+    await page.locator('.item-new-field-symbol').fill('€');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
+
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(schema.fields[0].symbol).toBe('€');
+  });
+
+  test('should set 0 as default value for currency fields on existing items', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'default-' + Date.now();
+    const slug = await createCollectionViaApi(request, name, [], [{ id: 'i1', name: 'Existing Item' }]);
+    await gotoCollectionView(page, slug);
+    await clickAddField(page);
+
+    await page.locator('.item-new-field-input').fill('Price');
+    await page.locator('.item-new-field-type').selectOption('currency');
+    await page.locator('.item-new-field-input').press('Enter');
+
+    await expect(page.locator('.item-new-field-form')).not.toBeVisible();
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    const schema = await (await request.get(`/api/list/data/${slug}/schema.json`)).json();
+    expect(items[0][schema.fields[0].key]).toBe(0);
+    expect(typeof items[0][schema.fields[0].key]).toBe('number');
+  });
+
+  test('should display currency value with symbol prefix', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'display-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 9.99 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await expect(page.locator('.item-field-value', { hasText: '$9.99' })).toBeVisible();
+  });
+
+  test('should display correct symbol for non-dollar currency', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'euro-sym-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'cost', name: 'Cost', type: 'currency', symbol: '€' }],
+      [{ id: 'i1', name: 'Item A', cost: 19.99 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await expect(page.locator('.item-field-value', { hasText: '€19.99' })).toBeVisible();
+  });
+
+  test('should render type=number input when editing a currency field', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'input-type-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 9.99 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '$9.99' }).click();
+
+    await expect(page.locator('.item-field-edit')).toHaveAttribute('type', 'number');
+  });
+
+  test('should populate edit input with raw number (no symbol)', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'edit-raw-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 9.99 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '$9.99' }).click();
+
+    await expect(page.locator('.item-field-edit')).toHaveValue('9.99');
+  });
+
+  test('should save currency value as a number in items.json', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'save-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 0 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '$0.00' }).click();
+    await page.locator('.item-field-edit').fill('24.99');
+    await page.locator('.item-field-edit').press('Enter');
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    expect(items[0].price).toBeCloseTo(24.99);
+    expect(typeof items[0].price).toBe('number');
+  });
+
+  test('should display updated value with symbol after edit', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'display-after-edit-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 0 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '$0.00' }).click();
+    await page.locator('.item-field-edit').fill('42');
+    await page.locator('.item-field-edit').press('Enter');
+
+    await expect(page.locator('.item-field-value', { hasText: '$42.00' })).toBeVisible();
+  });
+
+  test('should save 0 when currency field is cleared', async ({ request, page }) => {
+    const name = TEST_PREFIX + 'clear-' + Date.now();
+    const slug = await createCollectionViaApi(request, name,
+      [{ key: 'price', name: 'Price', type: 'currency', symbol: '$' }],
+      [{ id: 'i1', name: 'Item A', price: 9.99 }]
+    );
+    await gotoCollectionView(page, slug);
+
+    await page.locator('.item-field-value', { hasText: '$9.99' }).click();
+    await page.locator('.item-field-edit').fill('');
+    await page.locator('.item-field-edit').press('Enter');
+
+    const items = await (await request.get(`/api/list/data/${slug}/items.json`)).json();
+    expect(items[0].price).toBe(0);
+  });
+});


### PR DESCRIPTION
## Story

Closes #37, closes #38

- As a user I want to be able to add a currency field so that I can track financial data
- As a user I want currency fields to show a currency symbol so that financial data is clear

**Acceptance criteria:**
- User can add a field of type `currency`
- Currency field stores a numeric value (float)
- Currency symbol is configurable per field (default `$`)
- Symbol is displayed as a prefix in the list view (e.g. `$9.99`, `€19.99`)
- Edit input uses `type=number` with `step=any`; raw number shown (no symbol) during edit

## Changes

- `field.ts` — added `currency` variant to `FieldDraft`/`Field` union; `fieldDefault` returns `0`; `parseFieldValue` parses as float; new `fieldInputType` and `fieldInputStep` helpers (switch-based, testable); new `formatFieldValue` formats with symbol and 2 decimal places
- `CollectionView.tsx` — `currency` option in type selector; symbol input shown when type is currency; `startEdit` strips symbol before populating input; render uses `formatFieldValue`; edit input uses `fieldInputType`/`fieldInputStep`
- `style.css` — `.item-new-field-symbol` added to shared selector + narrow width rule
- `field.test.ts` — tests for `fieldDefault`, `parseFieldValue`, `formatFieldValue`, `fieldInputType`, `fieldInputStep` on currency fields
- `field.integration.test.ts` — backfill, new-item defaults, and commitEdit flows for currency
- `currency-field.spec.js` — 13 E2E tests covering UI, persistence, display, and edit lifecycle

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] 76 unit/integration tests pass (`vitest run`)
- [x] 73 E2E tests pass (`npm test`)
- [ ] Manual: add a `$` currency field, enter a value, confirm `$X.XX` display
- [ ] Manual: change symbol to `€`, confirm correct prefix shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)